### PR TITLE
feat(Styled): adding `as` prop

### DIFF
--- a/lib/src/styled.tsx
+++ b/lib/src/styled.tsx
@@ -22,19 +22,19 @@ export function styled<T extends VariantsDefinition, C extends AnyComponent>(
     React.ElementRef<C>,
     React.ComponentProps<C> & {
       variants?: DefaultVariants<T>
+      as?: AnyComponent
     }
-  >(({ className, variants, ...props }, forwardedRef) => (
-    <PolymorphicComponent
-      className={
+  >(({ className, variants, as, ...props }, forwardedRef) =>
+    React.createElement(as ?? PolymorphicComponent, {
+      className:
         getClasses({
           ...variants, // Populate with chosen variants
           className, // Override those variants with class names on-demand
-        }) || undefined // Prevent empty string
-      }
-      {...props}
-      ref={forwardedRef}
-    />
-  ))
+        }) || undefined,
+      ref: forwardedRef,
+      ...props,
+    }),
+  )
 
   // Prevent component from showing as `Anonymous` (improves debugging)
   if (

--- a/lib/tests/react.spec.tsx
+++ b/lib/tests/react.spec.tsx
@@ -42,6 +42,17 @@ describe('React classnames', () => {
       expect(el?.className).toBe('base base-two red')
     })
 
+    test('single component using `as` prop', () => {
+      const id = newId()
+
+      const Div = styled('div', shareableConfig)
+      render(<Div as="main" id={id} />)
+
+      const el = document.getElementById(id)
+      expect(el?.className).toBe('base base-two red')
+      expect(el?.tagName).toBe('MAIN')
+    })
+
     test('nested components', () => {
       const id1 = newId()
       const id2 = newId()


### PR DESCRIPTION
## Description
This PR introduces a new prop, `as`, to the styled function component. This prop allows users to override the default HTML tag for the created element.

For example, consider the following `Text` component:

```ts
const Text = cz("span", {
  variants: {
    type: {
      title: cx("text-lg", "font-semibold"),
      subTitle: cx("text-md", "font-normal", "text-slate-400"),
    },
  },
});
```
With the `as` prop, users can now specify the desired HTML tag for the generated element:

```ts
<Text as="h1" variants={{ type: "title" }}>
  Sup🔥
</Text>
```
This results in the following rendered HTML:
```html
<h1 className="text-lg font-semibold">Sup🔥</h1>
```
The `as` prop is useful for ensuring semantic HTML code and allows users to override the default `div` tag with more meaningful tags such as `section`, `article`, and `main`.